### PR TITLE
beta-16 : prevent strange characters from model name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-v0.3 beta16 (not yet released)
+v0.3 beta17 (not yet released)
 =============================
  * --foreground added
  * Fix some error messages wrongly ouput to stdout instead of stderr
@@ -6,6 +6,10 @@ v0.3 beta16 (not yet released)
  * Consider field 194 as a temperature in Celsius if the disk
    is not present in hddtemp.db.
  * Update config.{guess,sub}
+
+v0.3 beta16 (not yet released)
+=============================
+ * Fix invalid characters on the disk model name
 
 v0.3 beta15
 =============================

--- a/configure
+++ b/configure
@@ -1648,7 +1648,7 @@ fi
 
 # Define the identity of the package.
  PACKAGE=hddtemp
- VERSION=0.3-beta15
+ VERSION=0.3-beta16
 
 
 cat >>confdefs.h <<_ACEOF

--- a/configure.in
+++ b/configure.in
@@ -8,7 +8,7 @@ AC_CONFIG_HEADERS([config.h])
 # Determine the host and build type. The target is always a PIC.
 AC_CANONICAL_HOST
 
-AM_INIT_AUTOMAKE(hddtemp, 0.3-beta15)
+AM_INIT_AUTOMAKE(hddtemp, 0.3-beta16)
 
 dnl Checks for programs.
 AC_PROG_CC

--- a/src/sata.c
+++ b/src/sata.c
@@ -88,7 +88,7 @@ static const char *sata_model (int device) {
     return strdup(_("unknown"));
   else
   {
-    sata_fixstring(identify + 54, 24);
+    sata_fixstring(identify + 54, 40);
     return strdup(identify + 54);
   }
 }


### PR DESCRIPTION
Some devices had strange character caused by model name buffer overflow. 
![image](https://user-images.githubusercontent.com/784536/150607983-201df649-7b10-4fdd-a2e8-e39610f43568.png)

This PR hotfixing this issue.